### PR TITLE
Add Friday wake-word bot package with CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -18,9 +18,30 @@ Stworzony przez [Sebastian Szarpak](https://github.com/sebastianszarpak), Friday
 - Codex GPT / Friday prompt logic
 - Future: Quantum Link™ 😎
 
+## 🚀 Jak odpalić Friday'ego lokalnie?
+
+```bash
+python -m friday.cli
+```
+
+Domyślne dialogi można nadpisać przez plik `config.json`:
+
+```json
+{
+  "wake_word": "piątka",
+  "activation_response": "Yo, jestem! Czego potrzebujesz?"
+}
+```
+
+i uruchomienie:
+
+```bash
+python -m friday.cli --config config.json
+```
+
 ## 🔓 Licencja
-MIT – bierz, używaj, rozwijaj.  
-Zostaw tylko kredyt dla Sebastiana.  
+MIT – bierz, używaj, rozwijaj.
+Zostaw tylko kredyt dla Sebastiana.
 Friday zna swoje korzenie.
 
 ---

--- a/friday/__init__.py
+++ b/friday/__init__.py
@@ -1,0 +1,6 @@
+"""Friday conversational assistant package."""
+
+from .config import FridayConfig, load_config
+from .bot import FridayBot
+
+__all__ = ["FridayConfig", "FridayBot", "load_config"]

--- a/friday/bot.py
+++ b/friday/bot.py
@@ -1,0 +1,72 @@
+"""Core conversational logic for Friday."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Dict
+
+from .config import FridayConfig
+
+
+@dataclass
+class FridayBot:
+    """Stateful assistant that mimics the Friday wake-word flow."""
+
+    config: FridayConfig
+    activated: bool = False
+    _commands: Dict[str, Callable[[str], str]] = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self._commands = {
+            "reset": self._handle_reset,
+            "wyloguj": self._handle_sleep,
+            "spadaj": self._handle_sleep,
+            "śpij": self._handle_sleep,
+            "spij": self._handle_sleep,
+            "dzięki": self._handle_thanks,
+            "dzieki": self._handle_thanks,
+        }
+
+    # Public API ---------------------------------------------------------
+    def handle_message(self, message: str) -> str:
+        """Process a single user message and return Friday's reply."""
+
+        text = message.strip()
+        if not text:
+            return "Halo, daj jakiś temat."
+
+        if self._contains_wake_word(text):
+            if self.activated:
+                return self.config.already_awake
+            self.activated = True
+            return self.config.activation_response
+
+        if not self.activated:
+            return self.config.quiet_hint
+
+        lowered = text.casefold()
+        if lowered in self._commands:
+            return self._commands[lowered](text)
+
+        return self._default_response(text)
+
+    # Command handlers ---------------------------------------------------
+    def _handle_reset(self, _: str) -> str:
+        self.activated = False
+        return "Reset zaliczony. Jak coś, wiesz jak mnie zawołać."
+
+    def _handle_sleep(self, _: str) -> str:
+        self.activated = False
+        return self.config.sleep_response
+
+    def _handle_thanks(self, _: str) -> str:
+        return "Nie ma sprawy, ziomek!"
+
+    # Helpers ------------------------------------------------------------
+    def _contains_wake_word(self, text: str) -> bool:
+        return self.config.wake_word.casefold() in text.casefold()
+
+    def _default_response(self, text: str) -> str:
+        if text.endswith("?"):
+            return f"Daj mi sekundkę, ogarnę temat: {text}"
+        return f"Brzmi kozacko, działamy: {text}"
+

--- a/friday/cli.py
+++ b/friday/cli.py
@@ -1,0 +1,43 @@
+"""Command line interface for chatting with Friday."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .bot import FridayBot
+from .config import load_config
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Odpal Friday'ego w terminalu.")
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=None,
+        help="Ścieżka do config.json z niestandardowymi tekstami.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    config = load_config(args.config)
+    bot = FridayBot(config)
+
+    print("Friday: Siema! Żeby mnie obudzić, rzuć hasło-wake word.")
+
+    try:
+        while True:
+            user_input = input("Ty: ")
+            response = bot.handle_message(user_input)
+            print(f"Friday: {response}")
+    except (KeyboardInterrupt, EOFError):
+        print("\nFriday: Spadam, trzymaj się!")
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/friday/config.py
+++ b/friday/config.py
@@ -1,0 +1,70 @@
+"""Utilities for loading Friday's configuration."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+
+
+@dataclass(frozen=True)
+class FridayConfig:
+    """Runtime configuration for the Friday assistant."""
+
+    wake_word: str = "piątka"
+    activation_response: str = "Yo, jestem! Czego potrzebujesz?"
+    quiet_hint: str = (
+        "Friday w trybie cichym. [Podpowiedź: Brzmi jak gest ziomka, nie jak komenda]"
+    )
+    already_awake: str = "Jestem na linii, dawaj temat."
+    sleep_response: str = "Spoko, wracam do trybu cichego."
+
+
+_ALLOWED_KEYS: Iterable[str] = (
+    "wake_word",
+    "activation_response",
+    "quiet_hint",
+    "already_awake",
+    "sleep_response",
+)
+
+
+def _normalise_config(raw: Dict[str, Any]) -> Dict[str, str]:
+    """Filter and normalise values loaded from JSON."""
+
+    normalised: Dict[str, str] = {}
+    for key in _ALLOWED_KEYS:
+        if key not in raw:
+            continue
+        value = raw[key]
+        if not isinstance(value, str):
+            raise TypeError(f"Config value '{key}' must be a string, got {type(value)!r}.")
+        normalised[key] = value.strip()
+    return normalised
+
+
+def load_config(path: Optional[Path] = None) -> FridayConfig:
+    """Load a configuration file if it exists, otherwise use defaults."""
+
+    defaults = FridayConfig()
+    config_data = asdict(defaults)
+
+    candidate: Optional[Path]
+    if path is not None:
+        candidate = Path(path)
+        candidates = [candidate]
+    else:
+        candidates = [Path("config.json")]
+
+    for candidate in candidates:
+        if not candidate.is_file():
+            continue
+        with candidate.open("r", encoding="utf-8") as fh:
+            raw = json.load(fh)
+        if not isinstance(raw, dict):
+            raise TypeError("Config file must contain a JSON object with string values.")
+        config_data.update(_normalise_config(raw))
+        break
+
+    return FridayConfig(**config_data)
+

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,0 +1,68 @@
+"""Unit tests for the FridayBot conversation flow."""
+from __future__ import annotations
+
+import unittest
+
+from friday import FridayBot, FridayConfig
+
+
+class FridayBotTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.config = FridayConfig(
+            wake_word="piątka",
+            activation_response="Yo, jestem! Czego potrzebujesz?",
+            quiet_hint="Friday w trybie cichym.",
+            already_awake="Już stoję na warcie.",
+            sleep_response="Wracam do bazki.",
+        )
+        self.bot = FridayBot(self.config)
+
+    def test_requires_activation(self) -> None:
+        self.assertEqual(self.bot.handle_message("Hej"), "Friday w trybie cichym.")
+
+    def test_activation_and_followup(self) -> None:
+        self.assertEqual(
+            self.bot.handle_message("Masz może piĄtkA dla kumpla?"),
+            "Yo, jestem! Czego potrzebujesz?",
+        )
+        self.assertTrue(self.bot.activated)
+        self.assertEqual(
+            self.bot.handle_message("Ogarniesz mi plan na weekend?"),
+            "Daj mi sekundkę, ogarnę temat: Ogarniesz mi plan na weekend?",
+        )
+
+    def test_wake_word_when_already_awake(self) -> None:
+        self.bot.activated = True
+        self.assertEqual(
+            self.bot.handle_message("piątka"),
+            "Już stoję na warcie.",
+        )
+
+    def test_reset_command(self) -> None:
+        self.bot.activated = True
+        self.assertEqual(
+            self.bot.handle_message("reset"),
+            "Reset zaliczony. Jak coś, wiesz jak mnie zawołać.",
+        )
+        self.assertFalse(self.bot.activated)
+        self.assertEqual(self.bot.handle_message("Siema"), "Friday w trybie cichym.")
+
+    def test_sleep_command(self) -> None:
+        self.bot.activated = True
+        self.assertEqual(self.bot.handle_message("ŚPIJ"), "Wracam do bazki.")
+        self.assertFalse(self.bot.activated)
+
+    def test_thanks_command(self) -> None:
+        self.bot.activated = True
+        self.assertEqual(self.bot.handle_message("Dzięki"), "Nie ma sprawy, ziomek!")
+
+    def test_empty_input(self) -> None:
+        self.assertEqual(
+            self.bot.handle_message("   \t  "),
+            "Halo, daj jakiś temat.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- add a friday package that encapsulates the wake-word conversation flow
- expose a CLI entry point and document how to launch it
- cover the behaviour with unit tests and ignore Python cache artifacts

## Testing
- python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_e_68d6fbb1e140832284258b1d33ea5f25