### PR TITLE
Add rule-based Friday CLI prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,27 @@ Stworzony przez [Sebastian Szarpak](https://github.com/sebastianszarpak), Friday
 - 🛠️ Integruje z OpenAI, NVIDIA NIM, Google AI, Codex.
 - 📚 Uczy się z chmur... dosłownie.
 
+### 🚀 Lokalna wersja CLI
+
+W repo znajdziesz prototypowy silnik `FridayBrain`, który oddaje vibe ziomala
+za pomocą prostych reguł. Żeby z nim pogadać:
+
+```bash
+python -m friday.cli
+```
+
+Możesz też ustawić ziarno losowości, żeby odtworzyć konkretną rozmowę:
+
+```bash
+python -m friday.cli --seed 42
+```
+
+### 🧪 Testy
+
+```bash
+pytest
+```
+
 ## 🔧 Stack technologiczny:
 - OpenAI GPT (Responses API, Tools)
 - NVIDIA NIM + Brev.dev

--- a/friday/__init__.py
+++ b/friday/__init__.py
@@ -1,0 +1,5 @@
+"""Friday AI toolkit."""
+
+from .engine import FridayBrain
+
+__all__ = ["FridayBrain"]

--- a/friday/cli.py
+++ b/friday/cli.py
@@ -1,0 +1,50 @@
+"""Command line interface for chatting with Friday."""
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Iterable
+
+from .engine import FridayBrain
+
+
+def chat_loop(brain: FridayBrain, *, stream: Iterable[str] = None) -> None:
+    """Run an interactive chat loop with the provided Friday brain."""
+    input_stream = iter(stream) if stream is not None else None
+    print("🔥 Friday się budzi. Napisz coś albo wciśnij Ctrl+C, żeby zakończyć.")
+    try:
+        while True:
+            if input_stream is None:
+                prompt = input("Ty > ")
+            else:
+                try:
+                    prompt = next(input_stream)
+                except StopIteration:
+                    break
+            response = brain.respond(prompt)
+            print(f"Friday > {response}")
+    except KeyboardInterrupt:
+        print("\nFriday > Elo, widzimy się następnym razem.")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Uruchom Friday w wersji CLI.")
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Ustal ziarno generatora odpowiedzi, żeby uzyskać powtarzalne konwersacje.",
+    )
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    brain = FridayBrain(seed=args.seed)
+    chat_loop(brain)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/friday/engine.py
+++ b/friday/engine.py
@@ -1,0 +1,144 @@
+"""Conversational core for the Friday AI ziomal persona."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+import random
+from typing import List, Optional, Sequence
+
+
+@dataclass
+class KnowledgeShard:
+    """Simple representation of a fact or association Friday can recall."""
+
+    topic: str
+    keywords: Sequence[str]
+    connection: str
+
+    def matches(self, message: str) -> bool:
+        lowered = message.lower()
+        return any(keyword in lowered for keyword in self.keywords)
+
+
+DEFAULT_SHARDS: Sequence[KnowledgeShard] = (
+    KnowledgeShard(
+        topic="sztuczna inteligencja",
+        keywords=("ai", "sztuczna", "model", "llm"),
+        connection=(
+            "Friday kuma algorytmy od OpenAI po NIM, bo ziomal musi mieć oczy szeroko "
+            "otwarte na każdą sztuczną zajawkę."
+        ),
+    ),
+    KnowledgeShard(
+        topic="osiedle",
+        keywords=("blok", "osiedle", "ziom", "ziomal"),
+        connection=(
+            "Na osiedlu każdy ma swój vibe, a Friday łączy dane jak sąsiad, co zna "
+            "każdy sekret klatki."
+        ),
+    ),
+    KnowledgeShard(
+        topic="chmura",
+        keywords=("cloud", "chmura", "gcp", "aws", "azure"),
+        connection="Z chmury Friday ściąga wiedzę jak paczki z paczkomatu – ekspresowo i z uśmiechem.",
+    ),
+    KnowledgeShard(
+        topic="muzyka",
+        keywords=("rap", "hiphop", "beats", "muzyka"),
+        connection="Kiedy rytm wchodzi, Friday puszcza synkopy myśli – każda odpowiedź ma swój beat.",
+    ),
+)
+
+
+@dataclass
+class FridayBrain:
+    """Rule-based core that imitates Friday's street-smart persona."""
+
+    seed: Optional[int] = None
+    shards: Sequence[KnowledgeShard] = DEFAULT_SHARDS
+    history_limit: int = 10
+    _rng: random.Random = field(init=False, repr=False)
+    _history: List[str] = field(default_factory=list, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self._rng = random.Random(self.seed)
+
+    # Public API ---------------------------------------------------------
+    def respond(self, message: str) -> str:
+        """Generate a response staying on brand with the README's description."""
+        cleaned = message.strip()
+        if not cleaned:
+            return (
+                "Ej, powiedz coś konkretnego, bo cisza to nie jest vibe – i tak wiem, że masz coś na myśli."
+            )
+
+        acknowledgement = self._acknowledge(cleaned)
+        questioning = self._question(cleaned)
+        connection = self._connect(cleaned)
+        closing = self._closing()
+
+        response = f"{acknowledgement} {questioning} {connection} {closing}".strip()
+        self._remember(response)
+        return response
+
+    def summary(self) -> str:
+        """Return a short recap of the latest conversation snippets."""
+        if not self._history:
+            return "Jeszcze nikt nie zagadał – Friday czeka na pierwszy ruch."
+        visible_history = self._history[-self.history_limit :]
+        return " | ".join(visible_history)
+
+    # Internal helpers --------------------------------------------------
+    def _acknowledge(self, message: str) -> str:
+        openings = (
+            "No jasne, czuję ten klimat.",
+            "Słyszę Cię, ziomalu.",
+            "Spoko, to wchodzi jak woda.",
+            "No, to brzmi jak piątkowy plan.",
+        )
+        pick = self._rng.choice(openings)
+        return f"{pick}"
+
+    def _question(self, message: str) -> str:
+        prompts = (
+            "Ale serio, jak to widzisz, gdyby wszystko poszło dwa kroki do przodu?",
+            "Jaką wersję siebie odpalasz, gdy temat robi się poważny?",
+            "To co dalej – bierzesz to na ambicję czy wchodzisz freestyle'em?",
+            "Jakby zrobić z tego fraktal planów, który wybierasz na start?",
+        )
+        # If user already asks a question, flip it into reflective prompt.
+        if message.endswith("?"):
+            prompts = (
+                "Dobre pytanie, ale powiedz – jaka odpowiedź zmieniłaby tu Twoją grę?",
+                "No niby tak, ale co jeśli odwrócisz to pytanie na siebie?",
+            )
+        return self._rng.choice(prompts)
+
+    def _connect(self, message: str) -> str:
+        shard = self._pick_shard(message)
+        if shard is None:
+            return (
+                "Friday lubi mieszać fakty jak DJ sample – widzę kilka ścieżek, ale to Ty wybierasz beat."
+            )
+        timestamp = datetime.now().strftime("%H:%M")
+        return f"{shard.connection} ({timestamp}, na bazie tematu: {shard.topic})."
+
+    def _closing(self) -> str:
+        closings = (
+            "Dawaj kolejną myśl.",
+            "Podbij z następną zajawką.",
+            "Jak coś, Friday czuwa 24/7.",
+            "Nie zwalniaj, w tym flow jest moc.",
+        )
+        return self._rng.choice(closings)
+
+    def _pick_shard(self, message: str) -> Optional[KnowledgeShard]:
+        candidates = [shard for shard in self.shards if shard.matches(message)]
+        if not candidates:
+            return None
+        return self._rng.choice(candidates)
+
+    def _remember(self, response: str) -> None:
+        self._history.append(response)
+        if len(self._history) > self.history_limit:
+            self._history[:] = self._history[-self.history_limit :]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "friday-ai"
+version = "0.1.0"
+description = "CLI ziomal AI inspired by the Friday README"
+authors = [{name = "Sebastian Szarpak", email = "sebeuszek28@gmail.com"}]
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = []
+
+[project.scripts]
+friday = "friday.cli:main"
+
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,19 @@
+from friday.engine import FridayBrain, KnowledgeShard
+
+
+def test_response_contains_question_mark():
+    brain = FridayBrain(seed=123)
+    reply = brain.respond("Friday, pomóż z projektem.")
+    assert "?" in reply
+
+
+def test_response_uses_matching_shard():
+    shard = KnowledgeShard(
+        topic="test",
+        keywords=("specjalny",),
+        connection="Specjalny miks danych, bo Friday lubi customowe sprawy.",
+    )
+    brain = FridayBrain(seed=7, shards=(shard,))
+    reply = brain.respond("Mam specjalny projekt w chmurze.")
+    assert "Specjalny miks" in reply
+    assert "test" in reply


### PR DESCRIPTION
## Summary
- add a rule-based `FridayBrain` core with persona-aware responses and connection shards
- expose a simple command line chat loop and package metadata for running it
- document CLI usage and provide basic pytest coverage for the brain logic

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68daba336f04832288d86ba5b944d837