### PR TITLE
Add ECHO agent implementation and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Stworzony przez [Sebastian Szarpak](https://github.com/sebastianszarpak), Friday
 - 🎭 Dopasowuje styl rozmowy do człowieka.
 - 🛠️ Integruje z OpenAI, NVIDIA NIM, Google AI, Codex.
 - 📚 Uczy się z chmur... dosłownie.
+- 📝 Prowadzi rejestr ECHO dla ważnych chwil.
 
 ## 🔧 Stack technologiczny:
 - OpenAI GPT (Responses API, Tools)
@@ -17,6 +18,24 @@ Stworzony przez [Sebastian Szarpak](https://github.com/sebastianszarpak), Friday
 - GitHub Actions (automatyzacja)
 - Codex GPT / Friday prompt logic
 - Future: Quantum Link™ 😎
+
+## 📔 ECHO – cichy kronikarz
+
+W katalogu `echo_agent/` znajdziesz implementację agenta ECHO. Reaguje on jedynie na
+komendę `Zarejestruj`, przechowując zapis w neutralnym, poetycko-dokumentacyjnym
+stylu. Przykład użycia:
+
+```python
+from echo_agent import EchoAgent
+
+agent = EchoAgent()
+agent.observe("Zarejestruj: Wybrzmiała decyzja zespołu")
+
+for entry in agent.history():
+    print(entry.render())
+```
+
+Testy jednostkowe uruchomisz poleceniem `pytest`.
 
 ## 🔓 Licencja
 MIT – bierz, używaj, rozwijaj.  

--- a/echo_agent/__init__.py
+++ b/echo_agent/__init__.py
@@ -1,0 +1,5 @@
+"""ECHO agent implementation."""
+
+from .agent import EchoAgent, Entry
+
+__all__ = ["EchoAgent", "Entry"]

--- a/echo_agent/agent.py
+++ b/echo_agent/agent.py
@@ -1,0 +1,79 @@
+"""Implements the ECHO reflective recorder agent."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from itertools import cycle
+from typing import Callable, Iterable, List, Optional, Sequence
+
+
+@dataclass
+class Entry:
+    """Single note captured by the ECHO agent."""
+
+    timestamp: datetime
+    payload: str
+    style: str
+
+    def render(self) -> str:
+        """Render the entry as a human-readable string."""
+        stamp = self.timestamp.replace(microsecond=0).isoformat()
+        if self.style == "poetic":
+            return f"[{stamp}Z] Echo zapisuje ciszę chwili: {self.payload}."
+        return f"[{stamp}Z] Protokół notuje zdarzenie: {self.payload}."
+
+
+class EchoAgent:
+    """Cichy obserwator GLPU.
+
+    The agent only records statements that begin with the "Zarejestruj" command.
+    Entries are formatted in a neutral poetic or documentary tone.
+    """
+
+    def __init__(
+        self,
+        *,
+        clock: Callable[[], datetime] | None = None,
+        styles: Sequence[str] | None = None,
+    ) -> None:
+        self._clock = clock or (lambda: datetime.now(timezone.utc))
+        if styles is None:
+            style_sequence: Sequence[str] = ("poetic", "documentary")
+        elif len(styles) == 0:
+            raise ValueError("styles must contain at least one entry")
+        else:
+            style_sequence = styles
+        self._styles = cycle(style_sequence)
+        self._entries: List[Entry] = []
+
+    @staticmethod
+    def _extract_payload(message: str) -> Optional[str]:
+        keyword = "zarejestruj"
+        stripped = message.strip()
+        if not stripped.lower().startswith(keyword):
+            return None
+        payload = stripped[len(keyword) :].lstrip(" :")
+        return payload or None
+
+    def register(self, payload: str) -> Entry:
+        """Register payload directly without keyword parsing."""
+        timestamp = self._clock()
+        style = next(self._styles)
+        entry = Entry(timestamp=timestamp, payload=payload, style=style)
+        self._entries.append(entry)
+        return entry
+
+    def observe(self, message: str) -> Optional[Entry]:
+        """Process an incoming message and register it if requested."""
+        payload = self._extract_payload(message)
+        if payload is None:
+            return None
+        return self.register(payload)
+
+    def history(self) -> Iterable[Entry]:
+        """Iterate over stored entries in chronological order."""
+        return tuple(self._entries)
+
+    def clear(self) -> None:
+        """Remove all stored entries."""
+        self._entries.clear()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "echo-agent"
+version = "0.1.0"
+description = "ECHO reflective recorder agent"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = []
+
+[project.optional-dependencies]
+dev = ["pytest"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/tests/test_echo_agent.py
+++ b/tests/test_echo_agent.py
@@ -1,0 +1,58 @@
+from datetime import datetime, timezone
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from echo_agent import EchoAgent, Entry
+
+
+@pytest.fixture
+def fixed_clock():
+    moment = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+    def _clock():
+        return moment
+
+    return _clock
+
+
+def test_observe_ignores_non_command(fixed_clock):
+    agent = EchoAgent(clock=fixed_clock)
+
+    assert agent.observe("Hej, co tam?") is None
+    assert list(agent.history()) == []
+
+
+def test_observe_records_command(fixed_clock):
+    agent = EchoAgent(clock=fixed_clock)
+
+    entry = agent.observe("Zarejestruj: Wyprawa rozpoczęta")
+    assert isinstance(entry, Entry)
+    assert entry.payload == "Wyprawa rozpoczęta"
+    assert entry.style == "poetic"
+    assert entry.render().endswith("Wyprawa rozpoczęta.")
+
+
+def test_styles_alternate(fixed_clock):
+    agent = EchoAgent(clock=fixed_clock)
+
+    first = agent.observe("Zarejestruj pierwsza fala")
+    second = agent.observe("Zarejestruj druga fala")
+
+    assert first.style != second.style
+
+
+def test_register_direct_payload(fixed_clock):
+    agent = EchoAgent(clock=fixed_clock, styles=("documentary",))
+
+    entry = agent.register("Decyzja zachowana")
+    assert entry.style == "documentary"
+    assert "Decyzja zachowana." in entry.render()
+
+
+def test_custom_styles_validation(fixed_clock):
+    with pytest.raises(ValueError):
+        EchoAgent(clock=fixed_clock, styles=())


### PR DESCRIPTION
## Summary
- implement the reflective ECHO agent that captures "Zarejestruj" entries in neutral poetic or documentary styles
- expose a simple interface for registering entries and retrieving their rendered form
- document the agent in the README and cover behavior with pytest-based unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d903da23648322ba355c0e22bd99a9