### PR TITLE
Restore MIT license and add privacy policy document

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,91 +1,21 @@
-# Polityka prywatności aplikacji FREEDAY
+MIT License
 
-**Wersja obowiązująca od:** [data]
+Copyright (c) 2025 Sebastian Szarpak
 
-## 1. Postanowienia ogólne
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-1.1. Niniejsza Polityka prywatności wyjaśnia, jakie dane osobowe zbiera aplikacja **FREEDAY**, w jakim celu, jak je przetwarza i jakie prawa przysługują użytkownikom.
-1.2. Korzystanie z aplikacji oznacza akceptację zasad określonych w tej Polityce (chyba że użytkownik wycofa zgodę w zakresie, w jakim to możliwe).
-1.3. Administratorem danych jest [imię i nazwisko lub nazwa firmy], z siedzibą w [adres], e-mail: [adres e-mail].
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-## 2. Zakres zbieranych danych
-
-2.1. Dane podawane dobrowolnie przez użytkownika:
-
-* imię / pseudonim
-* adres e-mail
-* inne dane, jeśli zostaną wprowadzone w aplikacji
-
-2.2. Dane techniczne:
-
-* identyfikator urządzenia
-* system operacyjny, typ urządzenia
-* adres IP
-* logi aplikacji, informacje o błędach i użyciu
-
-## 3. Cele przetwarzania danych
-
-* świadczenie funkcji aplikacji
-* kontakt z użytkownikiem (np. pomoc techniczna)
-* analiza i ulepszanie aplikacji
-* wypełnianie obowiązków prawnych
-
-## 4. Podstawy prawne
-
-* zgoda użytkownika
-* niezbędność do realizacji umowy / usługi
-* prawnie uzasadniony interes
-* obowiązki prawne
-
-## 5. Udostępnianie danych
-
-5.1. Dane mogą być udostępniane:
-
-* dostawcom usług IT (hosting, analiza)
-* partnerom technologicznym (np. dostawca API czatu)
-* organom publicznym, jeśli wymagają tego przepisy
-
-5.2. Dane nie są sprzedawane ani wykorzystywane do celów marketingowych bez zgody użytkownika.
-
-## 6. Przekazywanie danych poza EOG
-
-Jeśli dane są przekazywane poza Europejski Obszar Gospodarczy, zapewnione zostaną odpowiednie zabezpieczenia (np. standardowe klauzule umowne).
-
-## 7. Czas przechowywania danych
-
-Dane są przechowywane przez czas niezbędny do realizacji celów, a następnie usuwane lub anonimizowane.
-
-## 8. Prawa użytkownika
-
-Użytkownik ma prawo do:
-
-* dostępu do danych
-* sprostowania
-* usunięcia (prawo do bycia zapomnianym)
-* ograniczenia przetwarzania
-* przenoszenia danych
-* wniesienia sprzeciwu
-* wycofania zgody
-* skargi do organu nadzorczego (PUODO)
-
-## 9. Pliki cookies i technologie pokrewne
-
-Aplikacja może wykorzystywać technologie śledzenia (np. identyfikatory urządzeń) w celach:
-
-* zachowania sesji
-* analityki
-* diagnostyki
-
-## 10. Zabezpieczenia danych
-
-Stosujemy środki techniczne i organizacyjne: szyfrowanie, autoryzacja dostępu, kopie zapasowe, audyty.
-
-## 11. Zmiany w Polityce prywatności
-
-O istotnych zmianach poinformujemy w aplikacji. Data obowiązywania nowej wersji będzie podana na górze dokumentu.
-
-## 12. Kontakt
-
-W sprawach związanych z przetwarzaniem danych:
-
-kontakt meilowy
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,91 @@
+# Polityka prywatności aplikacji FREEDAY
+
+**Wersja obowiązująca od:** [data]
+
+## 1. Postanowienia ogólne
+
+1.1. Niniejsza Polityka prywatności wyjaśnia, jakie dane osobowe zbiera aplikacja **FREEDAY**, w jakim celu, jak je przetwarza i jakie prawa przysługują użytkownikom.
+1.2. Korzystanie z aplikacji oznacza akceptację zasad określonych w tej Polityce (chyba że użytkownik wycofa zgodę w zakresie, w jakim to możliwe).
+1.3. Administratorem danych jest [imię i nazwisko lub nazwa firmy], z siedzibą w [adres], e-mail: [adres e-mail].
+
+## 2. Zakres zbieranych danych
+
+2.1. Dane podawane dobrowolnie przez użytkownika:
+
+* imię / pseudonim
+* adres e-mail
+* inne dane, jeśli zostaną wprowadzone w aplikacji
+
+2.2. Dane techniczne:
+
+* identyfikator urządzenia
+* system operacyjny, typ urządzenia
+* adres IP
+* logi aplikacji, informacje o błędach i użyciu
+
+## 3. Cele przetwarzania danych
+
+* świadczenie funkcji aplikacji
+* kontakt z użytkownikiem (np. pomoc techniczna)
+* analiza i ulepszanie aplikacji
+* wypełnianie obowiązków prawnych
+
+## 4. Podstawy prawne
+
+* zgoda użytkownika
+* niezbędność do realizacji umowy / usługi
+* prawnie uzasadniony interes
+* obowiązki prawne
+
+## 5. Udostępnianie danych
+
+5.1. Dane mogą być udostępniane:
+
+* dostawcom usług IT (hosting, analiza)
+* partnerom technologicznym (np. dostawca API czatu)
+* organom publicznym, jeśli wymagają tego przepisy
+
+5.2. Dane nie są sprzedawane ani wykorzystywane do celów marketingowych bez zgody użytkownika.
+
+## 6. Przekazywanie danych poza EOG
+
+Jeśli dane są przekazywane poza Europejski Obszar Gospodarczy, zapewnione zostaną odpowiednie zabezpieczenia (np. standardowe klauzule umowne).
+
+## 7. Czas przechowywania danych
+
+Dane są przechowywane przez czas niezbędny do realizacji celów, a następnie usuwane lub anonimizowane.
+
+## 8. Prawa użytkownika
+
+Użytkownik ma prawo do:
+
+* dostępu do danych
+* sprostowania
+* usunięcia (prawo do bycia zapomnianym)
+* ograniczenia przetwarzania
+* przenoszenia danych
+* wniesienia sprzeciwu
+* wycofania zgody
+* skargi do organu nadzorczego (PUODO)
+
+## 9. Pliki cookies i technologie pokrewne
+
+Aplikacja może wykorzystywać technologie śledzenia (np. identyfikatory urządzeń) w celach:
+
+* zachowania sesji
+* analityki
+* diagnostyki
+
+## 10. Zabezpieczenia danych
+
+Stosujemy środki techniczne i organizacyjne: szyfrowanie, autoryzacja dostępu, kopie zapasowe, audyty.
+
+## 11. Zmiany w Polityce prywatności
+
+O istotnych zmianach poinformujemy w aplikacji. Data obowiązywania nowej wersji będzie podana na górze dokumentu.
+
+## 12. Kontakt
+
+W sprawach związanych z przetwarzaniem danych:
+
+kontakt meilowy


### PR DESCRIPTION
## Summary
- restore the MIT license text in the LICENSE file to align with the project documentation
- add a dedicated PRIVACY.md file containing the application's privacy policy details

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68d90283ee288322b57142cd2f242aeb