### PR TITLE
Implement modular Friday workflow with tests

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,17 @@
+"""Entry point demonstrating the Friday AI workflow."""
+
+import module1
+import module2
+import module3
+
+
+def main() -> None:
+    """Run the startup, runtime, and boot phases sequentially."""
+
+    module1.start()
+    module2.run()
+    module3.boot()
+
+
+if __name__ == "__main__":
+    main()

--- a/module1.py
+++ b/module1.py
@@ -1,0 +1,61 @@
+"""Utilities for starting the Friday AI workflow."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class StartupContext:
+    """Information captured when the system is started."""
+
+    started_at: datetime
+    message: str
+
+
+_context: Optional[StartupContext] = None
+
+__all__ = ["StartupContext", "start", "ensure_started", "get_context"]
+
+
+def start(message: str | None = None) -> StartupContext:
+    """Initialise the system and return the startup context.
+
+    Subsequent calls reuse the first created context to prevent duplicated
+    initialisation work.  The optional ``message`` argument lets callers
+    customise the user-facing notification logged during start-up.
+    """
+
+    global _context
+    if _context is None:
+        startup_message = message or "Friday core warming up."
+        _context = StartupContext(
+            started_at=datetime.now(timezone.utc), message=startup_message
+        )
+        logger.info("%s", startup_message)
+    else:
+        logger.debug("start() called again – reusing existing startup context.")
+    return _context
+
+
+def ensure_started(message: str | None = None) -> StartupContext:
+    """Ensure a startup context exists and return it."""
+
+    return start(message) if _context is None else _context
+
+
+def get_context() -> StartupContext:
+    """Return the existing startup context.
+
+    Raises:
+        RuntimeError: If :func:`start` has not been called yet.
+    """
+
+    if _context is None:
+        raise RuntimeError("Friday has not been started yet. Call start() first.")
+    return _context

--- a/module2.py
+++ b/module2.py
@@ -1,0 +1,56 @@
+"""Runtime utilities for the Friday AI workflow."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional
+
+import module1
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RunReport:
+    """Details about a system run."""
+
+    started_at: datetime
+    run_at: datetime
+    status: str
+    message: str
+
+
+_last_report: Optional[RunReport] = None
+
+__all__ = ["RunReport", "run", "get_last_run_report"]
+
+
+def run(status: str = "operational", message: str | None = None) -> RunReport:
+    """Execute the system run and store a report."""
+
+    global _last_report
+    context = module1.ensure_started()
+    run_time = datetime.now(timezone.utc)
+    run_message = message or "Friday runtime online."
+    _last_report = RunReport(
+        started_at=context.started_at,
+        run_at=run_time,
+        status=status,
+        message=run_message,
+    )
+    logger.info("%s", run_message)
+    return _last_report
+
+
+def get_last_run_report() -> RunReport:
+    """Return the most recent run report.
+
+    Raises:
+        RuntimeError: If :func:`run` has not been called yet.
+    """
+
+    if _last_report is None:
+        raise RuntimeError("module2.run() has not been called yet.")
+    return _last_report

--- a/module3.py
+++ b/module3.py
@@ -1,0 +1,55 @@
+"""Boot sequence helpers for the Friday AI workflow."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+import module2
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:  # pragma: no cover - import for type checkers only
+    from module2 import RunReport
+
+
+@dataclass(frozen=True)
+class BootStatus:
+    """A snapshot of the system boot state."""
+
+    run_report: "RunReport"
+    booted_at: datetime
+    ready: bool
+    message: str
+
+    @property
+    def started_at(self) -> datetime:
+        """Shortcut to the startup timestamp."""
+
+        return self.run_report.started_at
+
+    @property
+    def run_at(self) -> datetime:
+        """Shortcut to the runtime timestamp."""
+
+        return self.run_report.run_at
+
+
+__all__ = ["BootStatus", "boot"]
+
+
+def boot(message: str | None = None) -> BootStatus:
+    """Complete the boot sequence using the latest run report."""
+
+    report = module2.get_last_run_report()
+    boot_message = message or "Friday AI fully operational."
+    status = BootStatus(
+        run_report=report,
+        booted_at=datetime.now(timezone.utc),
+        ready=True,
+        message=boot_message,
+    )
+    logger.info("%s", boot_message)
+    return status

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,0 +1,70 @@
+"""Tests for the Friday AI workflow modules."""
+
+from __future__ import annotations
+
+import importlib
+from datetime import datetime, timezone
+
+import pytest
+
+import module1
+import module2
+import module3
+
+
+@pytest.fixture(autouse=True)
+def fresh_modules():
+    """Reload modules before each test to ensure isolated state."""
+
+    for module in (module1, module2, module3):
+        importlib.reload(module)
+    yield
+    for module in (module1, module2, module3):
+        importlib.reload(module)
+
+
+def test_full_workflow():
+    """The happy path should populate each phase object."""
+
+    context = module1.start("Test start-up sequence.")
+    assert isinstance(context.started_at, datetime)
+    assert context.started_at.tzinfo == timezone.utc
+    assert context.message == "Test start-up sequence."
+
+    report = module2.run(message="Test runtime execution.")
+    assert report.started_at == context.started_at
+    assert report.run_at >= context.started_at
+    assert report.status == "operational"
+    assert report.message == "Test runtime execution."
+
+    status = module3.boot(message="Test boot confirmation.")
+    assert status.ready is True
+    assert status.run_report == report
+    assert status.booted_at >= report.run_at
+    assert status.message == "Test boot confirmation."
+    assert status.started_at == context.started_at
+    assert status.run_at == report.run_at
+
+
+def test_get_last_run_report_requires_run():
+    """Attempting to fetch a report without running should fail."""
+
+    with pytest.raises(RuntimeError):
+        module2.get_last_run_report()
+
+
+def test_boot_requires_run():
+    """Boot should not proceed without a prior run."""
+
+    module1.start()
+    with pytest.raises(RuntimeError):
+        module3.boot()
+
+
+def test_start_is_idempotent():
+    """Calling ``start`` repeatedly should reuse the first context."""
+
+    first = module1.start("Initial start message.")
+    second = module1.start("Second attempt should be ignored.")
+    assert first is second
+    assert second.message == "Initial start message."


### PR DESCRIPTION
## Summary
- add separate modules to manage start, run, and boot phases for the Friday workflow
- provide a simple main entrypoint wiring the modules together
- configure pytest and cover the workflow with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690b7026647c83228344bdf77527be6b