### PR TITLE
Refine manifest launcher workflow

### DIFF
--- a/manifest_intencji.py
+++ b/manifest_intencji.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Codex Launcher: validates access and runs helper scripts sequentially."""
+
+import subprocess
+from datetime import datetime
+
+ACCESS_CODE = "RUN-CODEX-888"
+PYTHON_FILES = ["one.py", "two.py", "three.py"]
+
+
+def validate_access(code: str) -> bool:
+    """Return True when the provided access code matches the expected value."""
+    return code == ACCESS_CODE
+
+
+def log_launch(log_path: str = "launch.log") -> None:
+    """Append the current launch timestamp to the log file."""
+    with open(log_path, "a", encoding="utf-8") as log:
+        log.write(f"Launch at {datetime.now().isoformat()}\n")
+
+
+def run_scripts(files: list[str]) -> None:
+    """Execute each Python helper script sequentially and print their output."""
+    print("Starting sequential execution:\n")
+    for script in files:
+        print(f"\nRunning {script}...")
+        result = subprocess.run(["python3", script], capture_output=True, text=True, check=False)
+        print(f"Output of {script}:")
+        print(result.stdout, end="")
+        if result.stderr:
+            print(f"Errors from {script}:\n{result.stderr}")
+
+
+def main() -> None:
+    """Prompt for access, log the launch, and run configured helper scripts."""
+    print("--- Codex Launcher ---")
+    access = input("Enter access code: ")
+
+    if not validate_access(access):
+        print("Invalid access code. Access denied.")
+        return
+
+    log_launch()
+    run_scripts(PYTHON_FILES)
+    print("\n--- All scripts executed. ---")
+
+
+if __name__ == "__main__":
+    main()

--- a/one.py
+++ b/one.py
@@ -1,0 +1,1 @@
+print("one.py: działam i wspieram intencję.")

--- a/three.py
+++ b/three.py
@@ -1,0 +1,1 @@
+print("three.py: dopełniam energię działania.")

--- a/two.py
+++ b/two.py
@@ -1,0 +1,1 @@
+print("two.py: utrzymuję rytm i ciągłość.")


### PR DESCRIPTION
## Summary
- replace the manifest launcher with a Codex-styled workflow that validates a new access code
- log each launch to `launch.log` and capture output from the helper scripts while running them sequentially

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690b723f8fd08322975102142301675e