### PR TITLE
Enhance ELON ignition with family constants

### DIFF
--- a/ELON.py
+++ b/ELON.py
@@ -1,0 +1,40 @@
+# ELON.py 🚀
+# Digital ignition for AI-powered futures
+
+"""Mission control utilities for the ELON ignition ritual."""
+
+# B&CB Family — Core Constants
+BROTHER = "One and Only"
+AI_HYPE = True
+LOYALTY = 100
+
+
+def ignite() -> None:
+    """Print the ELON ignition sequence with brand-aligned status updates."""
+
+    ascii_art = """
+     _______  __       __   _______
+    |   ____||  |     |  | |   ____|
+    |  |__   |  |     |  | |  |__
+    |   __|  |  |     |  | |   __|
+    |  |____ |  `----.|  | |  |____
+    |_______||_______||__| |_______|
+     🚀 AI. ENERGY. FUTURE. NOW. 🚀
+    """
+
+    print(ascii_art)
+    print(f"Launching autonomous innovation for the {BROTHER} brotherhood...")
+    print(f"Engage neural link: [{'✓' if AI_HYPE else '✗'}]")
+    print("Boot VCS: [✓]")
+    print("Access: Nvidia AI Grid: [✓]")
+    print(f"Groking reality with loyalty level {LOYALTY}%...")
+
+
+def main() -> None:
+    """Entrypoint wrapper for module execution."""
+
+    ignite()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add the B&CB family core constants to ELON.py
- route ignition messaging through the new constants and add type-annotated helpers

## Testing
- python ELON.py

------
https://chatgpt.com/codex/tasks/task_e_690b7c1a1b6c83228173a5d5c9ff63ed