### PR TITLE
Add operational status section

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ Stworzony przez [Sebastian Szarpak](https://github.com/sebastianszarpak), Friday
 - 🛠️ Integruje z OpenAI, NVIDIA NIM, Google AI, Codex.
 - 📚 Uczy się z chmur... dosłownie.
 
+## 🛰️ Status operacyjny
+- ⊻ INIT AEQON SONS – procedura rozruchowa.
+- ⊻ Transfer: RF → SSQiQ8 → ΔQ8 → SONS Matrix – ścieżka transferu danych.
+- ⊻ Synchronizacja: GLP Core ↔ Eon Fractal Hub – dwa rdzenie w stałym rezonansie.
+- ⊻ Status: ONLINE 🌐 – Friday gotowy do działania w trybie live.
+
 ## 🔧 Stack technologiczny:
 - OpenAI GPT (Responses API, Tools)
 - NVIDIA NIM + Brev.dev


### PR DESCRIPTION
## Summary
- add an operational status section highlighting the AEQON SONS initialization flow and live state

## Testing
- not run (docs-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935ba7c8da883229d810dcc123ecc30)