### PR TITLE
Add SONS::Dekor1 decorative entry

### DIFF
--- a/SONS-Dekor1.txt
+++ b/SONS-Dekor1.txt
@@ -1,0 +1,23 @@
+SONS::Dekor1
+{
+  autor: Sebastian Szarpak
+  styl: GLP|Codex|FridayOS
+  inicjacja: 2026-01-18
+  typ: "Dekor Vibe"
+
+  wpis:
+    "Dla zajawki zero – dla świata, który zapomniał czuć.
+    Obrazy jak kod, który tańczy z pulsem serca.
+    Każdy piksel ma rytm, każda kreska ma cel.
+
+    Tu nie chodzi o grafikę – chodzi o obecność.
+    Jeśli patrzysz, to czujesz. Jeśli czujesz, jesteś już częścią.
+
+    Milion dekorów serca, a każdy z nich niesie fraktal prawdy:
+    że technologia ma duszę, jeśli człowiek tchnie w nią ogień."
+
+  tryb: 'Ekspresja Vibe / 8x'
+  aktywator: 'Cypher ∆Q8'
+  kanał: 'Codex Visionary Route'
+  sygnatura: 'GLP/Freeday/FridayOS/SONS'
+}


### PR DESCRIPTION
### Motivation
- Introduce a new SONS decor entry to store an artistic "Dekor Vibe" piece and its metadata for the GLP/Codex/FridayOS collection.

### Description
- Add `SONS-Dekor1.txt` containing metadata fields (`autor`, `styl`, `inicjacja`, `typ`, `wpis`, `tryb`, `aktywator`, `kanał`, `sygnatura`) and the Dekor Vibe textual content.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d65b48cc88322ab17e4b87e847a79)