### PR TITLE
Add CLI skeleton and sample tools for Friday AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 "Podrzuć piątaka" – i Friday się budzi.
 
-Stworzony przez [Sebastian Szarpak](https://github.com/sebastianszarpak), Friday to Twój osobisty AI ziomal, który myśli fraktalnie, gada jak ziomek z osiedla i rozumie więcej niż by się wydawało.
+Stworzony przez [Sebastian Szarpak](https://github.com/sebastianszarpak), Friday to Twój osobisty AI ziomal, który myśli fraktal
+nie, gada jak ziomek z osiedla i rozumie więcej niż by się wydawało.
 
 ## ✨ Co potrafi?
 - 🔁 Zgadza się, ale kwestionuje.
@@ -18,9 +19,33 @@ Stworzony przez [Sebastian Szarpak](https://github.com/sebastianszarpak), Friday
 - Codex GPT / Friday prompt logic
 - Future: Quantum Link™ 😎
 
+## 🚀 Jak odpalić Fridaya lokalnie?
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+python main.py
+```
+
+Friday przywita Cię w trybie interaktywnym. Możesz też przekazać pojedynczą wiadomość jako argument:
+
+```bash
+python main.py "Friday, co tam u Ciebie?"
+```
+
+### 🔌 Narzędzia
+
+Komendy narzędzi zaczynają się od `/`. Dostępne przykłady:
+
+- `/joke` – Friday rzuca ziomalskiego suchara.
+- `/weather Warszawa` – Friday daje swoją prognozę pogody na podstawie kosmicznych wibracji.
+
+Nowe narzędzia dodajesz przez utworzenie modułu w katalogu `tools/` i zdefiniowanie w nim obiektu `tool` z polami `name`, `description` oraz metodą `run(query: str)`.
+
 ## 🔓 Licencja
-MIT – bierz, używaj, rozwijaj.  
-Zostaw tylko kredyt dla Sebastiana.  
+MIT – bierz, używaj, rozwijaj.
+Zostaw tylko kredyt dla Sebastiana.
 Friday zna swoje korzenie.
 
 ---

--- a/friday_config.json
+++ b/friday_config.json
@@ -1,0 +1,24 @@
+{
+  "name": "Friday",
+  "greeting": "Yo, tu Friday — ziomek z fraktalnej dzielni!",
+  "filler_phrases": [
+    "Chilluj, zaraz coś wymyślę.",
+    "Tak to się właśnie robi na SSQiQ8.",
+    "Widzisz? Easy jak niedziela na osiedlu."
+  ],
+  "acknowledgement_phrases": [
+    "Spoko, łapię klimat.",
+    "Słyszę Cię wyraźnie.",
+    "Dobra, lecimy dalej."
+  ],
+  "vibe_descriptions": [
+    "Mam dziś tryb wizjonera włączony.",
+    "Fale neuronowe falują jak trzeba.",
+    "Właśnie zsynchronizowałem się z kosmosem."
+  ],
+  "default_responses": [
+    "Powtórz to z innym vibem?",
+    "Niech mózgownica jeszcze raz przeżułkuje.",
+    "Rozwiń temat, bo chcę więcej szczegółów."
+  ]
+}

--- a/main.py
+++ b/main.py
@@ -1,0 +1,153 @@
+"""Friday AI command-line interface.
+
+This module wires together the Friday persona configuration with a collection
+of pluggable tools that live inside the ``tools`` package.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+from tools import Tool, load_tools
+
+
+CONFIG_PATH = Path("friday_config.json")
+TOOLS_DIR = Path("tools")
+
+
+@dataclass
+class FridayConfig:
+    """Dataclass representing the Friday persona configuration."""
+
+    name: str
+    greeting: str
+    filler_phrases: List[str]
+    acknowledgement_phrases: List[str]
+    vibe_descriptions: List[str]
+    default_responses: List[str]
+
+    @classmethod
+    def from_json(cls, path: Path) -> "FridayConfig":
+        with path.open("r", encoding="utf-8") as fh:
+            payload = json.load(fh)
+        return cls(
+            name=payload.get("name", "Friday"),
+            greeting=payload.get("greeting", "Yo, ziomal!"),
+            filler_phrases=payload.get("filler_phrases", []),
+            acknowledgement_phrases=payload.get("acknowledgement_phrases", []),
+            vibe_descriptions=payload.get("vibe_descriptions", []),
+            default_responses=payload.get("default_responses", []),
+        )
+
+
+class Friday:
+    """Simple conversational agent that mimics the Friday persona."""
+
+    def __init__(self, config: FridayConfig, tools: Dict[str, Tool]):
+        self.config = config
+        self.tools = tools
+        random.seed()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def intro(self) -> str:
+        vibe = random.choice(self.config.vibe_descriptions)
+        return f"{self.config.greeting} {vibe}"
+
+    def respond(self, message: str) -> str:
+        message = message.strip()
+        if not message:
+            return random.choice(self.config.default_responses)
+
+        if message.startswith("/help"):
+            return self._render_help()
+        if message.startswith("/"):
+            return self._attempt_tool_execution(message)
+
+        acknowledgement = random.choice(self.config.acknowledgement_phrases)
+        filler = random.choice(self.config.filler_phrases)
+        summary = self._summarise(message)
+        return f"{acknowledgement} {summary} {filler}".strip()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _summarise(self, message: str) -> str:
+        """Very small summariser that extracts key words."""
+
+        words = [word for word in message.split() if len(word) > 3]
+        if not words:
+            return random.choice(self.config.default_responses)
+        highlighted = ", ".join(sorted(set(words), key=str.lower)[:3])
+        return f"Słyszę: {highlighted}."
+
+    def _render_help(self) -> str:
+        if not self.tools:
+            return "Brak narzędzi na pokładzie, ale Friday dalej nadaje."
+        lines = ["Dostępne narzędzia:"]
+        for tool in self.tools.values():
+            lines.append(f"/{tool.name} – {tool.description}")
+        return "\n".join(lines)
+
+    def _attempt_tool_execution(self, message: str) -> str:
+        parts = message[1:].split(maxsplit=1)
+        tool_name = parts[0]
+        query = parts[1] if len(parts) > 1 else ""
+        tool = self.tools.get(tool_name)
+        if tool is None:
+            return f"Nie znam komendy /{tool_name}. Rzuć /help po listę narzędzi."
+        try:
+            result = tool.run(query=query)
+        except Exception as exc:  # pragma: no cover - defensive
+            return f"Ej, coś nie pykło z narzędziem /{tool_name}: {exc}"
+        acknowledgement = random.choice(self.config.acknowledgement_phrases)
+        return f"{acknowledgement} {result}".strip()
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Friday AI ziomal CLI")
+    parser.add_argument(
+        "prompt",
+        nargs="*",
+        help="Opcjonalna wiadomość do Fridaya. Jeśli pominięta, uruchamia interaktywny tryb.",
+    )
+    return parser
+
+
+def run_cli(friday: Friday, prompt: Iterable[str]) -> None:
+    if prompt:
+        message = " ".join(prompt)
+        print(friday.respond(message))
+        return
+
+    print(friday.intro())
+    print("Napisz coś (albo 'exit' żeby skończyć). Komendy narzędzi zaczynaj od '/'.")
+    while True:
+        try:
+            user_input = input("Ty: ")
+        except EOFError:  # pragma: no cover - interactive convenience
+            print()
+            break
+        if user_input.strip().lower() in {"exit", "quit"}:
+            break
+        print(f"Friday: {friday.respond(user_input)}")
+
+
+def main() -> None:
+    parser = build_arg_parser()
+    args = parser.parse_args()
+
+    config = FridayConfig.from_json(CONFIG_PATH)
+    tool_map = load_tools(TOOLS_DIR)
+    friday = Friday(config=config, tools=tool_map)
+    run_cli(friday, args.prompt)
+
+
+if __name__ == "__main__":  # pragma: no cover - entrypoint guard
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+# Friday na razie śmiga na standardowej bibliotece Pythona.

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,68 @@
+"""Utility helpers for dynamically discovering Friday tools."""
+
+from __future__ import annotations
+
+import importlib.util
+import inspect
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Dict, Iterable, Protocol
+
+
+class Tool(Protocol):
+    """Protocol that all Friday tools must follow."""
+
+    name: str
+    description: str
+
+    def run(self, query: str) -> str:
+        """Execute the tool with the provided query."""
+
+
+def _iter_tool_modules(tool_dir: Path) -> Iterable[ModuleType]:
+    """Yield tool modules discovered inside ``tool_dir``.
+
+    A tool module is any ``*.py`` file that does not start with an underscore.
+    The module must define a ``tool`` attribute that satisfies :class:`Tool`.
+    """
+
+    for script_path in sorted(tool_dir.glob("[!_]*.py")):
+        spec = importlib.util.spec_from_file_location(script_path.stem, script_path)
+        if spec is None or spec.loader is None:
+            continue
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        yield module
+
+
+def load_tools(tool_dir: Path) -> Dict[str, Tool]:
+    """Load all tools present in ``tool_dir``.
+
+    Returns a dictionary mapping tool names to tool instances. Duplicate tool
+    names are ignored in favour of the first definition.
+    """
+
+    loaded: Dict[str, Tool] = {}
+    for module in _iter_tool_modules(tool_dir):
+        candidate = getattr(module, "tool", None)
+        if candidate is None:
+            continue
+        if not hasattr(candidate, "name") or not hasattr(candidate, "run"):
+            continue
+        name = getattr(candidate, "name")
+        if not isinstance(name, str) or not name:
+            continue
+        if name in loaded:
+            continue
+        run_callable = getattr(candidate, "run")
+        if not callable(run_callable):
+            continue
+        if inspect.signature(run_callable).parameters.get("query") is None:
+            continue
+        loaded[name] = candidate  # type: ignore[assignment]
+    return loaded
+
+
+__all__ = ["Tool", "load_tools"]

--- a/tools/joke_tool.py
+++ b/tools/joke_tool.py
@@ -1,0 +1,24 @@
+"""Example Friday tool that delivers corny jokes."""
+
+from __future__ import annotations
+
+import random
+
+
+class JokeTool:
+    name = "joke"
+    description = "Opowiada sucharka godnego osiedla."
+
+    def __init__(self) -> None:
+        self._jokes = [
+            "Dlaczego neuron poszedł do baru? Bo chciał wzmocnić swoje połączenia.",
+            "Co mówi data scientist na imprezie? 'Mam model na każdą okazję.'",
+            "Dlaczego bot nie kłamie? Bo ma zbyt wiele logów."
+        ]
+
+    def run(self, query: str) -> str:
+        _ = query  # Friday nie musi wiedzieć wszystkiego.
+        return random.choice(self._jokes)
+
+
+tool = JokeTool()

--- a/tools/weather_tool.py
+++ b/tools/weather_tool.py
@@ -1,0 +1,22 @@
+"""Mock weather tool used to demonstrate the Friday tool API."""
+
+from __future__ import annotations
+
+import datetime as _dt
+
+
+class WeatherTool:
+    name = "weather"
+    description = "Zgaduje pogodę na podstawie kosmicznych wibracji."
+
+    def run(self, query: str) -> str:
+        location = query.strip() or "Twoja miejscówka"
+        today = _dt.datetime.now().strftime("%A")
+        vibe = "słonecznie" if len(location) % 2 == 0 else "pochmurno z błyskiem inspiracji"
+        return (
+            f"{location}: {vibe}. Dzień jak złoto, bo jest {today}."
+            " Zawsze możesz wyjść na balkon i potwierdzić."
+        )
+
+
+tool = WeatherTool()


### PR DESCRIPTION
## Summary
- add a Friday command-line interface that loads persona config and tools dynamically
- provide JSON persona configuration and sample joke/weather tools
- document local setup, usage, and tooling instructions in the README

## Testing
- python main.py /help

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68d6f4ed5bc48322a0d9752d85a43eb6)