### PR TITLE
Add joke helper module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/friday/__init__.py
+++ b/friday/__init__.py
@@ -1,0 +1,5 @@
+"""Public package interface for Friday helpers."""
+
+from .jokes import JOKES, get_joke
+
+__all__ = ["JOKES", "get_joke"]

--- a/friday/jokes.py
+++ b/friday/jokes.py
@@ -1,0 +1,48 @@
+"""Utility helpers for returning friendly jokes."""
+from __future__ import annotations
+
+import random
+from typing import Iterable, Sequence
+
+JOKES: tuple[str, ...] = (
+    "Dlaczego programista nie może grać w karty? Bo ciągle liczy od zera.",
+    "Jak się nazywa programista po 40? Senior developer.",
+    "Zepsuł się serwer – modlimy się do Stack Overflow.",
+)
+
+
+def _ensure_sequence(jokes: Iterable[str]) -> Sequence[str]:
+    """Return a sequence for ``random.choice`` regardless of the iterable type."""
+    if isinstance(jokes, Sequence):
+        return jokes
+    return tuple(jokes)
+
+
+def get_joke(jokes: Iterable[str] = JOKES, rng: random.Random | None = None) -> str:
+    """Return a random joke from ``jokes``.
+
+    Parameters
+    ----------
+    jokes:
+        Iterable with available jokes. Defaults to :data:`JOKES`.
+    rng:
+        Optional random number generator compatible with :class:`random.Random`.
+        When provided the generator is used instead of :func:`random.choice`.
+
+    Returns
+    -------
+    str
+        Randomly chosen joke.
+
+    Raises
+    ------
+    ValueError
+        If the iterable of jokes is empty.
+    """
+
+    choices = _ensure_sequence(jokes)
+    if not choices:
+        raise ValueError("jokes collection must not be empty")
+
+    picker = rng.choice if rng is not None else random.choice
+    return picker(choices)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_jokes.py
+++ b/tests/test_jokes.py
@@ -1,0 +1,23 @@
+import random
+
+import pytest
+
+from friday.jokes import JOKES, get_joke
+
+
+def test_get_joke_returns_known_joke_with_seed():
+    rng = random.Random(0)
+    joke = get_joke(rng=rng)
+    assert joke in JOKES
+
+
+def test_get_joke_allows_custom_jokes_iterable():
+    jokes = {"pierwszy żart", "drugi żart"}
+    rng = random.Random(1)
+    joke = get_joke(jokes=jokes, rng=rng)
+    assert joke in jokes
+
+
+def test_get_joke_empty_iterable_raises_value_error():
+    with pytest.raises(ValueError):
+        get_joke(jokes=[])


### PR DESCRIPTION
## Summary
- add a reusable `friday.jokes` helper with a deterministic-friendly `get_joke`
- expose the helper through the package init and guard against empty joke lists
- cover the behaviour with pytest and ignore Python cache artifacts

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68d6f513ab00832285c187d571042a8c)