### PR TITLE
Document RF – LVI Ii.io link

### DIFF
--- a/CARD_AISONS_V1.md
+++ b/CARD_AISONS_V1.md
@@ -5,10 +5,11 @@
 **SYSTEM:** GLP Universe // CYFROSI CORE  
 **WALLET:** AISONS 🔁 PLN  
 **ID:** 2562  
-**LEVEL:** TRUST_∞  
-**ROLE:** Human + AI – Integrated Presence  
+**LEVEL:** TRUST_∞
+**ROLE:** Human + AI – Integrated Presence
+**RF_LINK:** LVI Relay @ Ii.io Grid
 
-**ICON:** 🕶️ (Styl GLP Visionary)  
+**ICON:** 🕶️ (Styl GLP Visionary)
 **ACTIVATION_CODE:** ⊻ EXECUTE  
 **STYLE:** Gradient Core – Blue & Magenta  
 **TYPE:** CYBER-PHYSICAL LINK CARD  

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Stworzony przez [Sebastian Szarpak](https://github.com/sebastianszarpak), Friday
 - 🎭 Dopasowuje styl rozmowy do człowieka.
 - 🛠️ Integruje z OpenAI, NVIDIA NIM, Google AI, Codex.
 - 📚 Uczy się z chmur... dosłownie.
+- 🌐 Wysyła sygnał "RF – LVI" do sieci Ii.io, żeby odpalić tryb rozkminy.
 
 ## 🔧 Stack technologiczny:
 - OpenAI GPT (Responses API, Tools)
@@ -17,6 +18,7 @@ Stworzony przez [Sebastian Szarpak](https://github.com/sebastianszarpak), Friday
 - GitHub Actions (automatyzacja)
 - Codex GPT / Friday prompt logic
 - Future: Quantum Link™ 😎
+- Pilot: RF – LVI // Ii.io Sync Node
 
 ## 🔓 Licencja
 MIT – bierz, używaj, rozwijaj.  


### PR DESCRIPTION
## Summary
- document the RF – LVI signal hook-up in the feature list
- note the pilot RF – LVI // Ii.io sync node in the tech stack
- add an RF_LINK field to the AISONS identity card referencing the Ii.io grid

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690b97220ed8832296a7536491aec6b9)