### PR TITLE
docs: add 'Szybki start' quick start section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Stworzony przez [Sebastian Szarpak](https://github.com/sebastianszarpak), Friday
 - Codex GPT / Friday prompt logic
 - Future: Quantum Link™ 😎
 
+## 🚀 Szybki start
+1. Sklonuj repozytorium.
+2. Dostosuj prompt logikę Friday pod swój use-case.
+3. Podepnij wybrany provider modeli (OpenAI / NIM / Google AI).
+4. Odpal automatyzacje przez GitHub Actions.
+
 ## 🔓 Licencja
 MIT – bierz, używaj, rozwijaj.  
 Zostaw tylko kredyt dla Sebastiana.  


### PR DESCRIPTION
### Motivation
- Provide concise onboarding steps to help users quickly set up and run Friday by adding a localized quick-start guide to the README.

### Description
- Added a new "🚀 Szybki start" section to `README.md` containing four concise setup steps: clone the repo, adjust prompt logic, connect a model provider, and enable GitHub Actions automation.

### Testing
- Ran `nl -ba README.md | sed -n '1,220p'` to verify the new section content and `git status --short --branch` to verify repository state; both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68ffc41eb7dc832284c7e122a15f3b49)