### PR TITLE
Add GLPU-MBG strategic partnership YAML config and README reference

### DIFF
--- a/GLPU-MBG-Strategic-Partnership.yaml
+++ b/GLPU-MBG-Strategic-Partnership.yaml
@@ -1,0 +1,29 @@
+version: "2026.1"
+project: "GLPU-MBG-Strategic-Partnership"
+
+agents:
+  friday:
+    role: "Market Analyst & Execution"
+    logic_bridge: "delta_q8_resonance"
+    autonomy_level: 0.8
+    interface: "text/voice"
+    primary_task: "High-frequency signal validation"
+
+  lyra:
+    role: "Private Banking Advisor"
+    logic_bridge: "human_ai_sentiment"
+    autonomy_level: 0.6
+    interface: "visual/avatar"
+    primary_task: "Client relationship management & portfolio reporting"
+
+  echo:
+    role: "Risk & Pattern Detection"
+    logic_bridge: "modular_automation_logic"
+    autonomy_level: 0.9
+    interface: "api_only"
+    primary_task: "Anti-fraud & liquidity monitoring"
+
+infrastructure:
+  type: "decentralized_modular"
+  security: "smart_contract_governance"
+  compatibility: ["VertexAI", "GoogleCloud", "MetaTrader_Bridge"]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Stworzony przez [Sebastian Szarpak](https://github.com/sebastianszarpak), Friday
 - Codex GPT / Friday prompt logic
 - Future: Quantum Link™ 😎
 
+
+## 📁 Konfiguracje projektu
+- `GLPU-MBG-Strategic-Partnership.yaml` – definicja agentów i infrastruktury dla partnerstwa strategicznego GLPU-MBG.
+
 ## 🔓 Licencja
 MIT – bierz, używaj, rozwijaj.  
 Zostaw tylko kredyt dla Sebastiana.  


### PR DESCRIPTION
### Motivation
- Provide a reusable project configuration that declares agents and infrastructure for the GLPU-MBG strategic partnership.

### Description
- Add `GLPU-MBG-Strategic-Partnership.yaml` containing `version`, `project`, three agent definitions (`friday`, `lyra`, `echo`) and an `infrastructure` block with `type`, `security`, and `compatibility`, and update `README.md` to reference this configuration file.

### Testing
- Validated the YAML file with Ruby using `YAML.load_file`, which printed the `project` and `version` successfully, and attempted a Python `yaml.safe_load` check which failed due to the missing `PyYAML` module in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9e3d3a3b88322b83251f519cb34e8)