### PR TITLE
Add GLPU Decision Registry smart contract

### DIFF
--- a/contracts/GLPU_DecisionRegistry.sol
+++ b/contracts/GLPU_DecisionRegistry.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/**
+ * @title GLPU_DecisionRegistry
+ * @dev Rejestr decyzji podejmowanych przez silnik ∆Q8 i agentów HumanAI
+ */
+contract GLPU_DecisionRegistry {
+    address public owner;
+
+    enum Agent {
+        Friday,
+        Lyra,
+        Echo
+    }
+
+    struct Decision {
+        Agent agent;
+        string action;
+        uint256 timestamp;
+        int256 sentimentScore;
+        bool authorized;
+    }
+
+    mapping(uint256 => Decision) public decisions;
+    uint256 public decisionCount;
+
+    event DecisionLogged(uint256 id, Agent agent, string action, bool authorized);
+
+    constructor() {
+        owner = msg.sender;
+    }
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "Only GLPU Owner can authorize");
+        _;
+    }
+
+    // Zapisywanie decyzji wygenerowanej przez Pythonowy silnik ∆Q8
+    function logAIDecision(Agent _agent, string memory _action, int256 _sentiment) public onlyOwner {
+        decisionCount++;
+        decisions[decisionCount] = Decision({
+            agent: _agent,
+            action: _action,
+            timestamp: block.timestamp,
+            sentimentScore: _sentiment,
+            authorized: true
+        });
+
+        emit DecisionLogged(decisionCount, _agent, _action, true);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide an on-chain registry to persist decisions produced by the ∆Q8 engine and HumanAI agents with owner-based authorization, timestamping, sentiment scoring, and an event for auditability.

### Description
- Add `contracts/GLPU_DecisionRegistry.sol` implementing `GLPU_DecisionRegistry` with an `Agent` enum, `Decision` struct, `decisions` mapping and `decisionCount` counter, `onlyOwner` modifier, `logAIDecision` function to store decisions, and `DecisionLogged` event.

### Testing
- Verified repository changes with `git status --short` and `git diff` and inspected the new file with `nl -ba contracts/GLPU_DecisionRegistry.sol`, and attempted `solc --version` which failed because the Solidity compiler is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9e41c94c08322bc07998e8c80384a)