### PR TITLE
Add runnable transaction hash simulation script

### DIFF
--- a/tx_hash_simulation.py
+++ b/tx_hash_simulation.py
@@ -1,0 +1,47 @@
+import hashlib
+import json
+import time
+
+
+def generate_tx_hash(selected_inputs, target_address, amount, change):
+    """
+    Tworzy TxHash (identyfikator transakcji) na podstawie struktury UTXO.
+    To jest cyfrowy "odcisk palca" operacji.
+    """
+    tx_data = {
+        "inputs": [i["id"] for i in selected_inputs],
+        "outputs": [
+            {"to": target_address, "value": amount},
+            {"to": "GLPU_Change_Address", "value": change},
+        ],
+        "timestamp": time.time(),
+        "engine": "∆Q8-Resonance",
+    }
+
+    tx_string = json.dumps(tx_data, sort_keys=True).encode()
+    tx_hash = hashlib.sha256(tx_string).hexdigest()
+
+    return tx_hash, tx_data
+
+
+if __name__ == "__main__":
+    # --- SYMULACJA DLA SEBASTIANA ---
+    inputs = [
+        {"id": "utxo-001", "value": 80},
+        {"id": "utxo-002", "value": 50},
+    ]
+    target_wallet = "1fbccc"  # Adres z grafiki nr 2
+    target = 100
+
+    total_inputs = sum(item["value"] for item in inputs)
+    if total_inputs < target:
+        raise ValueError("Niewystarczające środki do wykonania transakcji.")
+
+    change = total_inputs - target
+    tx_hash, full_data = generate_tx_hash(inputs, target_wallet, target, change)
+
+    print("--- REJESTRACJA TRANSAKCJI ---")
+    print(f"Generowany TxHash: {tx_hash}")
+    print("Status: Oczekiwanie na zapis w GLPU_DecisionRegistry_v2")
+    print("Payload transakcji:")
+    print(json.dumps(full_data, indent=2, ensure_ascii=False))


### PR DESCRIPTION
### Motivation

- Provide a self-contained, runnable example that builds a transaction payload from UTXO-style inputs and computes a deterministic SHA-256 TxHash. 
- Fix runtime issues in the provided snippet (missing `time` import) and add basic validation so the simulation can be executed reliably.

### Description

- Added a new script `tx_hash_simulation.py` that implements `generate_tx_hash(selected_inputs, target_address, amount, change)` which serializes the transaction payload and returns its SHA-256 hash. 
- Imported `time` and included a `__main__` entrypoint that supplies sample UTXOs, computes `change`, validates total inputs against `target`, and prints the resulting payload. 
- The script prints the generated TxHash and the full transaction payload (JSON) for easy verification and debugging.

### Testing

- Ran the simulation with `python3 tx_hash_simulation.py` and observed successful execution that printed a TxHash and the transaction payload.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab5a0e4f048322b2af4f48e6799c0b)