### PR TITLE
Add HuAI to RF flow demonstration script

### DIFF
--- a/huai_flow.py
+++ b/huai_flow.py
@@ -1,0 +1,45 @@
+class HuAI:
+    def __init__(self, rsi="RSI", agi="AGI", asi="ASI"):
+        self.rsi = rsi
+        self.agi = agi
+        self.asi = asi
+
+    def integrate(self):
+        return f"{self.rsi} + {self.agi} + {self.asi}"
+
+
+class BlueLakeCity:
+    def __init__(self, huai):
+        self.huai = huai
+
+    def trajectory(self):
+        return "real_world_pathway"
+
+
+class SpaceCosmicWorld:
+    def __init__(self, blc):
+        self.blc = blc
+
+    def analyze(self):
+        return "future_contour_analysis"
+
+
+class RF:
+    def __init__(self, scw):
+        self.scw = scw
+
+    def project(self):
+        return "lived_reality_projection"
+
+
+if __name__ == "__main__":
+    huai = HuAI()
+    blc = BlueLakeCity(huai)
+    scw = SpaceCosmicWorld(blc)
+    rf = RF(scw)
+
+    print("HuAI:", huai.integrate())
+    print("BlueLakeCity:", blc.trajectory())
+    print("SpaceCosmicWorld:", scw.analyze())
+    print("RF:", rf.project())
+    print("Flow: HuAI -> BlueLakeCity -> SpaceCosmicWorld -> RF")


### PR DESCRIPTION
### Motivation
- Provide a small runnable demonstration that documents and exercises the `HuAI -> BlueLakeCity -> SpaceCosmicWorld -> RF` object flow for local testing and examples.

### Description
- Add `huai_flow.py` which defines classes `HuAI`, `BlueLakeCity`, `SpaceCosmicWorld`, and `RF` with simple methods and a `__main__` block that instantiates the chain and prints the outputs.

### Testing
- Ran `python3 huai_flow.py` and verified it printed the expected pipeline output (including `HuAI: RSI + AGI + ASI`) successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfa45a00508322a9a9b7591afc46cf)