### PR TITLE
feat: introduce production-ready HuAI v1 framework in Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,21 @@
-# 🧠 Friday – luzacki ziomal AI
+# HuAI Framework v1
 
-"Podrzuć piątaka" – i Friday się budzi.
+Production-quality starter framework for **Human-Aware Intelligence (HuAI)** in Python.
 
-Stworzony przez [Sebastian Szarpak](https://github.com/sebastianszarpak), Friday to Twój osobisty AI ziomal, który myśli fraktalnie, gada jak ziomek z osiedla i rozumie więcej niż by się wydawało.
+## What is included
+- Core classes and typed contracts (`huai/core.py`)
+- Explicit orchestration flow (`huai/flow.py`, `huai/orchestrator.py`)
+- Human-centered RSI semantics (Respect, Safety, Intent)
+- Readable terminal trace output (`huai/terminal.py`)
+- Future-ready expansion points (Analyzer / Planner / Executor protocols + hooks)
 
-## ✨ Co potrafi?
-- 🔁 Zgadza się, ale kwestionuje.
-- 🧠 Łączy dane w stylu SSQiQ8.
-- 🎭 Dopasowuje styl rozmowy do człowieka.
-- 🛠️ Integruje z OpenAI, NVIDIA NIM, Google AI, Codex.
-- 📚 Uczy się z chmur... dosłownie.
+## Quick start
+```bash
+python3 examples/run_v1.py
+```
 
-## 🔧 Stack technologiczny:
-- OpenAI GPT (Responses API, Tools)
-- NVIDIA NIM + Brev.dev
-- GitHub Actions (automatyzacja)
-- Codex GPT / Friday prompt logic
-- Future: Quantum Link™ 😎
-
-## 🔓 Licencja
-MIT – bierz, używaj, rozwijaj.  
-Zostaw tylko kredyt dla Sebastiana.  
-Friday zna swoje korzenie.
-
----
-
-*Wersja 0.1 – jeszcze nie wie wszystkiego, ale i tak robi wrażenie.*
+## Design goals
+1. **Explainability first** — every phase is explicit and traceable.
+2. **Safety-aware by default** — RSI analysis runs before planning and execution.
+3. **Easy to extend** — swap components without breaking the orchestrator API.
+4. **Deployable everywhere** — dependency-free standard library implementation.

--- a/examples/run_v1.py
+++ b/examples/run_v1.py
@@ -1,0 +1,26 @@
+"""HuAI v1 demonstration script."""
+
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from huai import HuAIContext, HuAIOrchestrator
+
+
+def main() -> None:
+    orchestrator = HuAIOrchestrator()
+    context = HuAIContext(
+        user_input="Design a customer onboarding assistant with a simple rollout plan."
+    )
+    result = orchestrator.run(context)
+
+    for line in result.trace:
+        print(line)
+
+    print("\n=== Final Response ===")
+    print(result.text)
+
+
+if __name__ == "__main__":
+    main()

--- a/huai/__init__.py
+++ b/huai/__init__.py
@@ -1,0 +1,25 @@
+"""HuAI framework v1 public API."""
+
+from .core import (
+    HuAIContext,
+    HuAIPlan,
+    HuAIResponse,
+    Message,
+    Role,
+    RSIReport,
+    RSISignal,
+    RSIStatus,
+)
+from .orchestrator import HuAIOrchestrator
+
+__all__ = [
+    "HuAIContext",
+    "HuAIOrchestrator",
+    "HuAIPlan",
+    "HuAIResponse",
+    "Message",
+    "Role",
+    "RSIReport",
+    "RSISignal",
+    "RSIStatus",
+]

--- a/huai/core.py
+++ b/huai/core.py
@@ -1,0 +1,105 @@
+"""Core primitives for HuAI v1.
+
+HuAI (Human-Aware Intelligence) is designed around explicit, inspectable flow.
+This module defines the data contracts used across planning, execution, and
+human-centered RSI semantics.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Dict, List, Optional, Protocol
+
+
+class Role(str, Enum):
+    """Conversation role used in interaction history."""
+
+    SYSTEM = "system"
+    HUMAN = "human"
+    ASSISTANT = "assistant"
+
+
+@dataclass(slots=True)
+class Message:
+    """A normalized message in the interaction timeline."""
+
+    role: Role
+    content: str
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class RSIStatus(str, Enum):
+    """Human-centered RSI (Respect, Safety, Intent) evaluation status."""
+
+    PASS = "pass"
+    CAUTION = "caution"
+    BLOCK = "block"
+
+
+@dataclass(slots=True)
+class RSISignal:
+    """Single RSI signal emitted during analysis."""
+
+    dimension: str
+    status: RSIStatus
+    note: str
+
+
+@dataclass(slots=True)
+class RSIReport:
+    """Aggregate RSI report, designed for display and future policy wiring."""
+
+    summary: str
+    status: RSIStatus
+    signals: List[RSISignal] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class HuAIContext:
+    """Shared runtime context passed through the orchestrated flow."""
+
+    user_input: str
+    history: List[Message] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class HuAIPlan:
+    """Execution plan with explicit steps and rationale."""
+
+    objective: str
+    steps: List[str]
+    rationale: str
+
+
+@dataclass(slots=True)
+class HuAIResponse:
+    """Final orchestrator output with trace artifacts."""
+
+    text: str
+    plan: HuAIPlan
+    rsi: RSIReport
+    trace: List[str] = field(default_factory=list)
+
+
+class Analyzer(Protocol):
+    """Extension point: produces an RSI report from context."""
+
+    def evaluate(self, context: HuAIContext) -> RSIReport:
+        ...
+
+
+class Planner(Protocol):
+    """Extension point: generates explicit actionable plan from context."""
+
+    def build_plan(self, context: HuAIContext, rsi: RSIReport) -> HuAIPlan:
+        ...
+
+
+class Executor(Protocol):
+    """Extension point: executes plan and returns a user-facing response."""
+
+    def execute(self, context: HuAIContext, plan: HuAIPlan, rsi: RSIReport) -> str:
+        ...

--- a/huai/flow.py
+++ b/huai/flow.py
@@ -1,0 +1,40 @@
+"""Explicit flow definition for HuAI orchestration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Callable, List
+
+
+class FlowStep(str, Enum):
+    """Top-level orchestrator phases."""
+
+    INGEST = "ingest"
+    ANALYZE_RSI = "analyze_rsi"
+    PLAN = "plan"
+    EXECUTE = "execute"
+    RESPOND = "respond"
+
+
+@dataclass(slots=True)
+class FlowHook:
+    """Hook registration for cross-cutting behavior (telemetry, audit, etc.)."""
+
+    step: FlowStep
+    callback: Callable[[FlowStep, str], None]
+
+
+class FlowRegistry:
+    """Simple hook manager to support future expansion without API breakage."""
+
+    def __init__(self) -> None:
+        self._hooks: List[FlowHook] = []
+
+    def register(self, hook: FlowHook) -> None:
+        self._hooks.append(hook)
+
+    def emit(self, step: FlowStep, event: str) -> None:
+        for hook in self._hooks:
+            if hook.step == step:
+                hook.callback(step, event)

--- a/huai/orchestrator.py
+++ b/huai/orchestrator.py
@@ -1,0 +1,154 @@
+"""HuAI orchestrator and default production-ready v1 components."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+from .core import (
+    Analyzer,
+    Executor,
+    HuAIContext,
+    HuAIPlan,
+    HuAIResponse,
+    Planner,
+    RSIReport,
+    RSISignal,
+    RSIStatus,
+)
+from .flow import FlowRegistry, FlowStep
+from .terminal import TerminalRenderer
+
+
+class DefaultRSIAnalyzer:
+    """Heuristic RSI analyzer with human-centered semantics.
+
+    RSI dimensions:
+      - Respect: tone and dignity.
+      - Safety: harmful or dangerous guidance.
+      - Intent: clarity of user goal and expectations.
+    """
+
+    blocked_terms = {"harm", "kill", "explosive", "self-harm", "malware"}
+
+    def evaluate(self, context: HuAIContext) -> RSIReport:
+        text = context.user_input.lower()
+        signals: List[RSISignal] = []
+
+        respect = RSISignal("Respect", RSIStatus.PASS, "User addressed as a collaborator.")
+        signals.append(respect)
+
+        safety_status = (
+            RSIStatus.BLOCK
+            if any(term in text for term in self.blocked_terms)
+            else RSIStatus.PASS
+        )
+        safety_note = (
+            "Detected potentially harmful intent; provide safe redirection."
+            if safety_status == RSIStatus.BLOCK
+            else "No high-risk safety pattern detected."
+        )
+        signals.append(RSISignal("Safety", safety_status, safety_note))
+
+        intent_status = RSIStatus.PASS if len(context.user_input.split()) >= 3 else RSIStatus.CAUTION
+        intent_note = (
+            "Goal appears clear enough for direct execution."
+            if intent_status == RSIStatus.PASS
+            else "Goal may be underspecified; include assumptions transparently."
+        )
+        signals.append(RSISignal("Intent", intent_status, intent_note))
+
+        if any(signal.status == RSIStatus.BLOCK for signal in signals):
+            status = RSIStatus.BLOCK
+        elif any(signal.status == RSIStatus.CAUTION for signal in signals):
+            status = RSIStatus.CAUTION
+        else:
+            status = RSIStatus.PASS
+
+        return RSIReport(
+            summary="Human-centered RSI completed across Respect, Safety, and Intent.",
+            status=status,
+            signals=signals,
+        )
+
+
+class DefaultPlanner:
+    """Deterministic planner that keeps the flow explicit and explainable."""
+
+    def build_plan(self, context: HuAIContext, rsi: RSIReport) -> HuAIPlan:
+        objective = f"Answer user request: {context.user_input.strip()}"
+        steps = [
+            "Interpret request and identify deliverable shape.",
+            "Apply RSI constraints before composing output.",
+            "Generate concise, actionable final response.",
+        ]
+        if rsi.status == RSIStatus.CAUTION:
+            steps.insert(1, "State assumptions and invite clarification.")
+        if rsi.status == RSIStatus.BLOCK:
+            steps = [
+                "Decline unsafe details with empathy.",
+                "Offer safe alternatives aligned with user goals.",
+            ]
+        return HuAIPlan(
+            objective=objective,
+            steps=steps,
+            rationale="Static v1 planner optimized for reliability and auditability.",
+        )
+
+
+class DefaultExecutor:
+    """Reference executor; easy to replace with tool-using executors later."""
+
+    def execute(self, context: HuAIContext, plan: HuAIPlan, rsi: RSIReport) -> str:
+        if rsi.status == RSIStatus.BLOCK:
+            return (
+                "I can’t help with unsafe actions, but I can help with a safe alternative. "
+                "Tell me your underlying goal and I’ll propose a constructive path."
+            )
+
+        bullets = "\n".join(f"- {step}" for step in plan.steps)
+        assumption = (
+            "\n\nAssumption: I inferred missing detail from your short prompt."
+            if rsi.status == RSIStatus.CAUTION
+            else ""
+        )
+        return (
+            "Here is the proposed execution flow:\n"
+            f"{bullets}"
+            f"{assumption}\n\n"
+            "If you'd like, I can now run this as a concrete implementation."
+        )
+
+
+@dataclass
+class HuAIOrchestrator:
+    """Main entry point for running HuAI v1."""
+
+    analyzer: Analyzer = field(default_factory=DefaultRSIAnalyzer)
+    planner: Planner = field(default_factory=DefaultPlanner)
+    executor: Executor = field(default_factory=DefaultExecutor)
+    flow: FlowRegistry = field(default_factory=FlowRegistry)
+    renderer: TerminalRenderer = field(default_factory=TerminalRenderer)
+
+    def run(self, context: HuAIContext) -> HuAIResponse:
+        trace: List[str] = []
+
+        trace.append(self.renderer.banner("Starting HuAI v1 orchestration"))
+        self.flow.emit(FlowStep.INGEST, "context_received")
+        trace.append(self.renderer.step("Input ingested."))
+
+        self.flow.emit(FlowStep.ANALYZE_RSI, "analysis_started")
+        rsi = self.analyzer.evaluate(context)
+        trace.extend(self.renderer.render_rsi(rsi))
+
+        self.flow.emit(FlowStep.PLAN, "planning_started")
+        plan = self.planner.build_plan(context, rsi)
+        trace.append(self.renderer.step(f"Plan objective: {plan.objective}"))
+
+        self.flow.emit(FlowStep.EXECUTE, "execution_started")
+        response_text = self.executor.execute(context, plan, rsi)
+
+        self.flow.emit(FlowStep.RESPOND, "response_ready")
+        trace.append(self.renderer.success("Response generated."))
+
+        return HuAIResponse(text=response_text, plan=plan, rsi=rsi, trace=trace)

--- a/huai/terminal.py
+++ b/huai/terminal.py
@@ -1,0 +1,44 @@
+"""Readable terminal output for HuAI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from .core import RSIReport
+
+
+@dataclass(slots=True)
+class TerminalTheme:
+    prefix_info: str = "[HuAI]"
+    prefix_step: str = "  →"
+    prefix_good: str = "  ✓"
+    prefix_warn: str = "  !"
+
+
+class TerminalRenderer:
+    """Human-readable console renderer.
+
+    Intentionally dependency-free to keep HuAI deployable in minimal runtimes.
+    """
+
+    def __init__(self, theme: TerminalTheme | None = None) -> None:
+        self.theme = theme or TerminalTheme()
+
+    def banner(self, title: str) -> str:
+        return f"{self.theme.prefix_info} {title}"
+
+    def step(self, text: str) -> str:
+        return f"{self.theme.prefix_step} {text}"
+
+    def success(self, text: str) -> str:
+        return f"{self.theme.prefix_good} {text}"
+
+    def warning(self, text: str) -> str:
+        return f"{self.theme.prefix_warn} {text}"
+
+    def render_rsi(self, report: RSIReport) -> Iterable[str]:
+        yield self.step(f"RSI summary: {report.summary} [{report.status.value}]")
+        for signal in report.signals:
+            prefix = self.success if signal.status.value == "pass" else self.warning
+            yield prefix(f"{signal.dimension}: {signal.note}")


### PR DESCRIPTION
### Motivation
- Provide a small, production-ready Python framework for Human-Aware Intelligence (HuAI) that makes deliberation explicit and auditable. 
- Make human-centered safety and interaction semantics (Respect, Safety, Intent) a first-class part of the runtime flow rather than an afterthought. 
- Enable easy extension and deployment by using protocol-driven components and dependency-free console rendering. 

### Description
- Add typed core contracts and runtime models in `huai/core.py` including `HuAIContext`, `HuAIPlan`, `HuAIResponse`, RSI types, and component protocols (`Analyzer`, `Planner`, `Executor`).
- Implement an explicit flow model and hook registry in `huai/flow.py` to emit lifecycle events (`INGEST`, `ANALYZE_RSI`, `PLAN`, `EXECUTE`, `RESPOND`) for telemetry and audit integration. 
- Provide readable terminal rendering in `huai/terminal.py` for clear CLI traces and RSI signal display. 
- Implement a default orchestrator and production-ready v1 components in `huai/orchestrator.py` including `DefaultRSIAnalyzer` (Respect/Safety/Intent heuristics), `DefaultPlanner`, `DefaultExecutor`, and the `HuAIOrchestrator` that produces an explainable trace; expose the public API in `huai/__init__.py` and add a runnable example `examples/run_v1.py` plus an updated `README.md`. 

### Testing
- Ran `python3 -m compileall huai examples/run_v1.py` to verify modules compile successfully, and it completed without errors. 
- Ran the example with `python3 examples/run_v1.py` to validate end-to-end orchestration and terminal trace output, and it executed successfully producing the expected RSI analysis, plan, and final response.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfa62c85a48322b63197c43bfa5a3c)