### PR TITLE
Refactor repo into workspace with deployable React web app, TypeScript, Docker, and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  web:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+dist/
+.env
+.env.*
+.DS_Store
+coverage/
+*.log
+
+*.tsbuildinfo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+COPY apps/web/package.json apps/web/package.json
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM nginx:1.27-alpine
+COPY --from=build /app/apps/web/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -1,28 +1,41 @@
-# 🧠 Friday – luzacki ziomal AI
+# Friday
 
-"Podrzuć piątaka" – i Friday się budzi.
+Friday is now organized as a deployable web app with a clearer, scalable structure.
 
-Stworzony przez [Sebastian Szarpak](https://github.com/sebastianszarpak), Friday to Twój osobisty AI ziomal, który myśli fraktalnie, gada jak ziomek z osiedla i rozumie więcej niż by się wydawało.
+## Project structure
 
-## ✨ Co potrafi?
-- 🔁 Zgadza się, ale kwestionuje.
-- 🧠 Łączy dane w stylu SSQiQ8.
-- 🎭 Dopasowuje styl rozmowy do człowieka.
-- 🛠️ Integruje z OpenAI, NVIDIA NIM, Google AI, Codex.
-- 📚 Uczy się z chmur... dosłownie.
+```text
+.
+├── apps/
+│   └── web/                  # React + TypeScript app
+│       ├── src/
+│       │   ├── components/   # UI components split by responsibility
+│       │   ├── App.tsx
+│       │   └── main.tsx
+│       └── package.json
+├── .github/workflows/ci.yml  # Lint + build checks
+├── Dockerfile                # Production image (nginx)
+├── docker-compose.yml        # Local deployment wrapper
+└── package.json              # Workspace scripts
+```
 
-## 🔧 Stack technologiczny:
-- OpenAI GPT (Responses API, Tools)
-- NVIDIA NIM + Brev.dev
-- GitHub Actions (automatyzacja)
-- Codex GPT / Friday prompt logic
-- Future: Quantum Link™ 😎
+## Quick start
 
-## 🔓 Licencja
-MIT – bierz, używaj, rozwijaj.  
-Zostaw tylko kredyt dla Sebastiana.  
-Friday zna swoje korzenie.
+```bash
+npm install
+npm run dev
+```
 
----
+## Build for production
 
-*Wersja 0.1 – jeszcze nie wie wszystkiego, ale i tak robi wrażenie.*
+```bash
+npm run build
+```
+
+## Deploy with Docker
+
+```bash
+docker compose up --build
+```
+
+The app will be available at `http://localhost:8080`.

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -1,0 +1,25 @@
+import js from '@eslint/js'
+import globals from 'globals'
+import reactHooks from 'eslint-plugin-react-hooks'
+import reactRefresh from 'eslint-plugin-react-refresh'
+import tseslint from 'typescript-eslint'
+
+export default tseslint.config(
+  { ignores: ['dist'] },
+  {
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      ecmaVersion: 2022,
+      globals: globals.browser
+    },
+    plugins: {
+      'react-hooks': reactHooks,
+      'react-refresh': reactRefresh
+    },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+      'react-refresh/only-export-components': ['warn', { allowConstantExport: true }]
+    }
+  }
+)

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Friday AI</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@friday/web",
+  "version": "0.2.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "lint": "eslint .",
+    "preview": "vite preview --host 0.0.0.0 --port 4173"
+  },
+  "dependencies": {
+    "react": "^19.1.1",
+    "react-dom": "^19.1.1"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.31.0",
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
+    "@vitejs/plugin-react": "^5.0.0",
+    "eslint": "^9.31.0",
+    "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-react-refresh": "^0.4.20",
+    "globals": "^16.3.0",
+    "typescript": "~5.8.3",
+    "typescript-eslint": "^8.37.0",
+    "vite": "^7.0.4"
+  }
+}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,0 +1,15 @@
+import { CapabilitiesList } from './components/CapabilitiesList'
+import { HeroSection } from './components/HeroSection'
+import { StackList } from './components/StackList'
+
+function App() {
+  return (
+    <main className="layout">
+      <HeroSection />
+      <CapabilitiesList />
+      <StackList />
+    </main>
+  )
+}
+
+export default App

--- a/apps/web/src/components/CapabilitiesList.tsx
+++ b/apps/web/src/components/CapabilitiesList.tsx
@@ -1,0 +1,19 @@
+const capabilities = [
+  'Validates ideas while still questioning them.',
+  'Connects data points in a clear, practical way.',
+  'Adapts tone and communication style to the person.',
+  'Keeps context tidy for longer, more useful sessions.'
+]
+
+export function CapabilitiesList() {
+  return (
+    <section className="card">
+      <h2>What Friday can do</h2>
+      <ul>
+        {capabilities.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/apps/web/src/components/HeroSection.tsx
+++ b/apps/web/src/components/HeroSection.tsx
@@ -1,0 +1,11 @@
+export function HeroSection() {
+  return (
+    <section className="card hero">
+      <p className="badge">Friday • Personal AI</p>
+      <h1>Friday — your AI partner with real personality.</h1>
+      <p>
+        Friday keeps conversations human, challenges weak assumptions, and helps move ideas into action.
+      </p>
+    </section>
+  )
+}

--- a/apps/web/src/components/StackList.tsx
+++ b/apps/web/src/components/StackList.tsx
@@ -1,0 +1,16 @@
+const stack = ['OpenAI Responses API', 'NVIDIA NIM', 'Google AI', 'GitHub Actions', 'Codex workflows']
+
+export function StackList() {
+  return (
+    <section className="card">
+      <h2>Current stack</h2>
+      <div className="pill-row">
+        {stack.map((item) => (
+          <span className="pill" key={item}>
+            {item}
+          </span>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import App from './App'
+import './styles.css'
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+)

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1,0 +1,55 @@
+:root {
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  line-height: 1.5;
+  color: #e4e7ec;
+  background: #11151c;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.layout {
+  max-width: 860px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.card {
+  border: 1px solid #2c3440;
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  background: #161b24;
+}
+
+.hero h1 {
+  margin: 0.25rem 0 0.5rem;
+}
+
+.badge {
+  color: #9aa4b2;
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+ul {
+  padding-left: 1.2rem;
+  margin-bottom: 0;
+}
+
+.pill-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.pill {
+  background: #232b37;
+  border: 1px solid #354153;
+  border-radius: 999px;
+  padding: 0.3rem 0.7rem;
+  font-size: 0.9rem;
+}

--- a/apps/web/tsconfig.app.json
+++ b/apps/web/tsconfig.app.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/apps/web/tsconfig.node.json
+++ b/apps/web/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()]
+})

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,5 @@
+services:
+  friday-web:
+    build: .
+    ports:
+      - "8080:80"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "friday",
+  "version": "0.2.0",
+  "private": true,
+  "description": "Friday app monorepo",
+  "workspaces": [
+    "apps/*"
+  ],
+  "scripts": {
+    "dev": "npm run dev --workspace apps/web",
+    "build": "npm run build --workspace apps/web",
+    "lint": "npm run lint --workspace apps/web",
+    "preview": "npm run preview --workspace apps/web"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}


### PR DESCRIPTION
### Motivation

- Clarify project layout and ownership by introducing a workspace-based app structure and preparing the repository for a deployable web application.
- Split UI into small, focused components and add typing/linting to improve maintainability and developer experience.
- Add deployment assets so the app can be built and run in production (container + CI) with minimal setup.

### Description

- Reorganized into a workspace with a root `package.json` and `apps/web` containing a React + TypeScript app including `index.html`, `src/main.tsx`, `src/App.tsx`, component files `HeroSection`, `CapabilitiesList`, `StackList`, and `styles.css`.
- Added TypeScript and Vite configuration files (`tsconfig.*`, `vite.config.ts`) and a per-app `package.json` declaring runtime and dev dependencies and scripts (`dev`, `build`, `lint`, `preview`).
- Prepared deployment and CI: added a multi-stage `Dockerfile`, `docker-compose.yml`, and GitHub Actions workflow at `.github/workflows/ci.yml` to run `npm ci`, `npm run lint`, and `npm run build` on push/PR.
- Project hygiene and docs: added `.gitignore` (including `*.tsbuildinfo`), an ESLint config at `apps/web/eslint.config.js`, and rewrote `README.md` with structure, quick start, build, and Docker deploy instructions.

### Testing

- Ran `npm install` in this environment which failed with an npm registry `403 Forbidden`, preventing dependency installation.
- Ran `npm run build` which failed because dependencies were not installed and TypeScript/Vite modules were unavailable.
- No CI jobs were executed here; the created workflow will run `npm ci`, `npm run lint`, and `npm run build` when pushed to a CI-capable environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4d0cf0ba483229ba97ab044d63cf4)