### PR TITLE
docs: add security policy and merge checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ Stworzony przez [Sebastian Szarpak](https://github.com/sebastianszarpak), Friday
 - Codex GPT / Friday prompt logic
 - Future: Quantum Link™ 😎
 
+## 🔐 Security
+
+This is a public repository — do not commit secrets.
+
+- Never store API keys, tokens, service account files or credentials in the repo.
+- Do not use `VITE_*` variables for secrets. They are exposed to the browser bundle.
+- Backend-only secrets belong in `.env`, which must never be committed.
+- Use `.env.example` only as a reference for required variables.
+- Report vulnerabilities privately through GitHub Security Advisories.
+
 ## 🔓 Licencja
 MIT – bierz, używaj, rozwijaj.  
 Zostaw tylko kredyt dla Sebastiana.  

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest version of the `main` branch receives security updates.
+
+## Reporting a Vulnerability
+
+If you discover a security issue, report it privately using GitHub Security Advisories:
+
+https://github.com/officessai/friday-gpt-ssqiq8/security/advisories
+
+Do not open public issues for vulnerabilities, leaked credentials, API keys, tokens or potential security incidents.
+
+## Handling Secrets
+
+- Never commit `.env`, API keys, tokens, service account files or credentials.
+- Do not use `VITE_*` variables for secrets. Anything prefixed with `VITE_` is exposed to the browser bundle.
+- Gemini/OpenAI/Anthropic/xAI/API keys must remain server-side only.
+- Use `.env.example` only as a placeholder reference.
+- Real secrets belong in local `.env`, GitHub Encrypted Secrets or a provider secret manager.
+
+## Public Repository Notice
+
+This is a public repository. Treat all commits, pull requests and issues as visible to the internet.

--- a/docs/BEFORE_MERGE.md
+++ b/docs/BEFORE_MERGE.md
@@ -1,0 +1,31 @@
+# Before Merge Checklist
+
+Use this checklist before merging any pull request that changes code, configuration, deployment, security-sensitive files or integration logic.
+
+## Security
+
+- [ ] `.env` and `.env.*` are not committed.
+- [ ] No API key, token, credential or service account file appears in the diff.
+- [ ] No secrets are exposed through `VITE_*` variables.
+- [ ] Frontend code does not call APIs requiring private keys directly.
+- [ ] `.env.example` contains placeholders only.
+- [ ] `.gitignore` includes environment files, credentials, local databases and key files.
+- [ ] `SECURITY.md` exists and is current.
+- [ ] README contains a Security section.
+
+## Scope Control
+
+- [ ] The PR changes only the files required for its stated purpose.
+- [ ] No unrelated formatting, refactors or generated files are included.
+- [ ] Public files do not expose private project IDs, service account emails, tokens, screenshots or operational details.
+
+## Review
+
+- [ ] The PR title clearly describes the change.
+- [ ] The PR description includes Summary, Scope and Testing sections.
+- [ ] At least one final owner check is completed before merge.
+
+## Testing
+
+- [ ] Config/docs-only changes explain why runtime tests are not required.
+- [ ] Code changes include the relevant checks or manual testing notes.


### PR DESCRIPTION
## Summary

Adds the second security baseline layer for repository process and documentation.

## Changes included

- Add `SECURITY.md` with vulnerability reporting and secrets-handling rules.
- Add `docs/BEFORE_MERGE.md` as a Monday Mode merge gate checklist.
- Add a short Security section to `README.md`.

## Scope

This PR changes only security/process documentation:

- `SECURITY.md`
- `docs/BEFORE_MERGE.md`
- `README.md`

No changes to:

- application code
- runtime logic
- deployment
- architecture

## Testing

Documentation-only change.  
No runtime tests required.

## Status

Ready for review after PR #81 owner check / merge.